### PR TITLE
docs: edited README.md Building for iOS section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Ensure both `kivy` and `kivymd` are up to date (see below reference for more det
 
 Note:
 - Contributors are welcome to do that one, collected below some beginning instructions with some issues and solutions.
+- Rosetta 2 not necessary for arm64 using kivy-ios==2.2.1
 
 Good article here:
 - https://nrodrig1.medium.com/put-kivy-application-on-iphone-update-1cda12e79825


### PR DESCRIPTION
I just edited a bullet in the README.md with a bullet saying rosetta 2 not needed with kivy-ios==2.2.1.

This is going to be a moot point because this whole section will be overridden with the next pull request on the ios build issue.