### PR TITLE
fix: navigation menu image for iOS - new clean branch

### DIFF
--- a/libs/main_app.kv
+++ b/libs/main_app.kv
@@ -6,6 +6,7 @@
 #: import AIChatScreen libs.features.ai_chat.ai_chat_screen.AIChatScreen
 #: import Text2ImgScreen libs.features.ai_text_to_img.text2img_screen.Text2ImgScreen
 #: import AppNavigationBar libs.theme.app_navigation_bar.AppNavigationBar
+#: import MDNavigationDrawerHeaderOM libs.theme.MDNavDrawerHeaderOM.navigationdrawer.MDNavigationDrawerHeaderOM
 
 <AppScreen>:
     AppNavigationBar:
@@ -34,7 +35,7 @@
             radius: (0, 16, 16, 0)
             theme_text_color: "Primary"
             MDNavigationDrawerMenu:
-                MDNavigationDrawerHeader:
+                MDNavigationDrawerHeaderOM:
                     source: "libs/assets/logo-nav-drawer.png"
                     title: app.get_metadata()["name"]
                     text: app.get_metadata()["description"]

--- a/libs/theme/MDNavDrawerHeaderOM/navigationdrawer.kv
+++ b/libs/theme/MDNavDrawerHeaderOM/navigationdrawer.kv
@@ -1,0 +1,52 @@
+#:import Window kivy.core.window.Window
+#:import m_res kivymd.material_resources
+
+<MDNavigationDrawerHeaderOM>
+    adaptive_height: True
+
+    # costa-rica: replaced FitImage with BoxLayout with image
+    # FitImage:
+    #     id: logo
+    #     source: root.source
+    #     size_hint: None, None
+    #     size: label_box.height, label_box.height
+    BoxLayout:
+        orientation: "vertical"
+        Label:
+            text:""
+        Image:
+            size_hint_y:None
+            height:self.width
+            source: root.source
+            allow_stretch: True
+            keep_ratio: False
+        Label:
+            text:""
+    MDBoxLayout:
+        id: label_box
+        orientation: "vertical"
+        adaptive_height: True
+
+        MDLabel:
+            id: title
+            adaptive_height: True
+            halign: root.title_halign
+            text: root.title
+            font_style: root.title_font_style
+            font_size: root.title_font_size
+            color:
+                root.title_color \
+                if root.title_color else \
+                app.theme_cls.text_color
+
+        MDLabel:
+            id: text
+            adaptive_height: True
+            text: root.text
+            halign: root.text_halign
+            font_style: root.text_font_style
+            font_size: root.text_font_size
+            color:
+                root.text_color \
+                if root.text_color else \
+                app.theme_cls.text_color

--- a/libs/theme/MDNavDrawerHeaderOM/navigationdrawer.py
+++ b/libs/theme/MDNavDrawerHeaderOM/navigationdrawer.py
@@ -1,0 +1,160 @@
+import os
+from typing import Union
+from kivy.animation import Animation, AnimationTransition
+from kivy.clock import Clock
+from kivy.core.window import Window
+from kivy.properties import (
+    AliasProperty,
+    BooleanProperty,
+    ColorProperty,
+    NumericProperty,
+    ObjectProperty,
+    OptionProperty,
+    StringProperty,
+    VariableListProperty,
+)
+from kivymd.uix.boxlayout import MDBoxLayout
+
+# taken directly from MDNavigationDrawerHeader in /kivymd/uix/navigationdrawer/navigationdrawer.py
+class MDNavigationDrawerHeaderOM(MDBoxLayout):
+    """
+    Implements a header for a menu for :class:`~MDNavigationDrawer` class.
+
+    For more information, see in the :class:`~kivymd.uix.boxlayout.MDBoxLayout`
+    class documentation.
+
+    .. versionadded:: 1.0.0
+
+    .. code-block:: kv
+
+        MDNavigationDrawer:
+
+            MDNavigationDrawerMenu:
+
+                MDNavigationDrawerHeader:
+                    title: "Header title"
+                    text: "Header text"
+                    spacing: "4dp"
+                    padding: "12dp", 0, 0, "56dp"
+
+    .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/navigation-drawer-header.png
+        :align: center
+    """
+
+    source = StringProperty()
+    """
+    Image logo path.
+
+    .. code-block:: kv
+
+        MDNavigationDrawer:
+
+            MDNavigationDrawerMenu:
+
+                MDNavigationDrawerHeader:
+                    title: "Header title"
+                    text: "Header text"
+                    source: "logo.png"
+                    spacing: "4dp"
+                    padding: "12dp", 0, 0, "56dp"
+
+    .. image:: https://github.com/HeaTTheatR/KivyMD-data/raw/master/gallery/kivymddoc/navigation-drawer-header-source.png
+        :align: center
+
+    :attr:`source` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `''`.
+    """
+
+    title = StringProperty()
+    """
+    Title shown in the first line.
+
+    :attr:`title` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `''`.
+    """
+
+    title_halign = StringProperty("left")
+    """
+    Title halign first line.
+
+    :attr:`title_halign` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `'left'`.
+    """
+
+    title_color = ColorProperty(None)
+    """
+    Title text color in (r, g, b, a) or string format.
+
+    :attr:`title_color` is a :class:`~kivy.properties.ColorProperty`
+    and defaults to `None`.
+    """
+
+    title_font_style = StringProperty("H4")
+    """
+    Title shown in the first line.
+
+    :attr:`title_font_style` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `'H4'`.
+    """
+
+    title_font_size = StringProperty("34sp")
+    """
+    Title shown in the first line.
+
+    :attr:`title_font_size` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `'34sp'`.
+    """
+
+    text = StringProperty()
+    """
+    Text shown in the second line.
+
+    :attr:`text` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `''`.
+    """
+
+    text_halign = StringProperty("left")
+    """
+    Text halign first line.
+
+    :attr:`text_halign` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `'left'`.
+    """
+
+    text_color = ColorProperty(None)
+    """
+    Title text color in (r, g, b, a) or string format.
+
+    :attr:`text_color` is a :class:`~kivy.properties.ColorProperty`
+    and defaults to `None`.
+    """
+
+    text_font_style = StringProperty("H6")
+    """
+    Title shown in the first line.
+
+    :attr:`text_font_style` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `'H6'`.
+    """
+
+    text_font_size = StringProperty("20sp")
+    """
+    Title shown in the first line.
+
+    :attr:`text_font_size` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `'20sp'`.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        Clock.schedule_once(self.check_content)
+
+    def check_content(self, interval: Union[int, float]) -> None:
+        """Removes widgets that the user has not added to the container."""
+
+        if not self.title:
+            self.ids.label_box.remove_widget(self.ids.title)
+        if not self.text:
+            self.ids.label_box.remove_widget(self.ids.text)
+        if not self.source:
+            self.remove_widget(self.ids.logo)


### PR DESCRIPTION
This pull request fixes the issue for the image in the navigation menu being too large in iOS devices.
*This branch is branched from the master after pull request #11 was accepted.
## Description
The issue was with the MDNavigationDrawerHeader class's handling of the source image. MDNavigationDrawerHeader has a property FitImage that takes the source and places the image in the MDNavigationDrawerHeader. This works well in wide screens but for some reason when the screens shrink or are in the iPhone the image enlarges to a size unrecognizable and distorts the navigation menu.
## Solution
Created another class MDNavigationDrawerHeaderOM and replaced FitImage with a BoxLayout that does the same thing. However this BoxLayout and Image (child of BoxLayout that replaced FitImage) do not blow up in size when the screen gets small or on the iPhone.

The new class is in /libs/theme/MDNavigationDrawerHeaderOM.