### PR TITLE
feat: settings menu - added paste button for api keys and edited text…

### DIFF
--- a/libs/features/settings/settings_screen.kv
+++ b/libs/features/settings/settings_screen.kv
@@ -108,7 +108,7 @@
                             on_text: root.set_stability_ai_key(self.text)
                         MDIconButton:
                             icon: "content-paste"
-                            on_release: ai_system_initial_context.text = Clipboard.paste()
+                            on_release: stability_ai_key.text = Clipboard.paste()
                     # fake a full row to add spacing on mobile devices (see MDGridLayout container vertical spacing)
                     MDWidget:
                         size_hint: 0, 0

--- a/libs/features/settings/settings_screen.kv
+++ b/libs/features/settings/settings_screen.kv
@@ -1,3 +1,4 @@
+#:import Clipboard kivy.core.clipboard.Clipboard
 <SettingsScreen>
     AppScreenLayout:
         spacing: dp(20)
@@ -41,13 +42,18 @@
                         pos_hint: {"center_y": .5}
                         adaptive_width: False if app.is_screen_sm() else True
                         height: self.texture_size[1]
-                    MDTextField:
-                        id: open_ai_key
-                        pos_hint: {"center_y": .5}
-                        hint_text: "Open AI key value (see https://platform.openai.com)"
-                        helper_text: "[https://platform.openai.com/account/api-keys]"
-                        text: ""
-                        on_text: root.set_open_ai_key(self.text)
+                    MDBoxLayout:
+                        adaptive_height: True
+                        MDTextField:
+                            id: open_ai_key
+                            pos_hint: {"center_y": .5}
+                            hint_text: root.text_input_hint_text_open_ai
+                            helper_text: "[https://platform.openai.com/account/api-keys]"
+                            text: ""
+                            on_text: root.set_open_ai_key(self.text)
+                        MDIconButton:
+                            icon: "content-paste"
+                            on_release: open_ai_key.text = Clipboard.paste()
                     # fake a full row to add spacing on mobile devices (see MDGridLayout container vertical spacing)
                     MDWidget:
                         size_hint: 0, 0
@@ -91,13 +97,18 @@
                         pos_hint: {"center_y": .5}
                         adaptive_width: False if app.is_screen_sm() else True
                         height: self.texture_size[1]
-                    MDTextField:
-                        id: stability_ai_key
-                        pos_hint: {"center_y": .5}
-                        hint_text: "Stability AI key value (see https://stability.ai/)"
-                        helper_text: "[https://stability.ai/]"
-                        text: ""
-                        on_text: root.set_stability_ai_key(self.text)
+                    MDBoxLayout:
+                        adaptive_height: True
+                        MDTextField:
+                            id: stability_ai_key
+                            pos_hint: {"center_y": .5}
+                            hint_text: root.text_input_hint_text_stabilty_ai
+                            helper_text: "[https://stability.ai/]"
+                            text: ""
+                            on_text: root.set_stability_ai_key(self.text)
+                        MDIconButton:
+                            icon: "content-paste"
+                            on_release: ai_system_initial_context.text = Clipboard.paste()
                     # fake a full row to add spacing on mobile devices (see MDGridLayout container vertical spacing)
                     MDWidget:
                         size_hint: 0, 0

--- a/libs/features/settings/settings_screen.py
+++ b/libs/features/settings/settings_screen.py
@@ -6,9 +6,12 @@ from kivy.clock import Clock
 from libs.theme.base_screen import BaseScreen
 from libs.theme.theme import PRIMARY_COLORS, ThemeMode
 from libs.features.settings.preferences_service import PreferencesService, Preferences
-
+from kivy.properties import StringProperty
+from kivy import platform
 
 class SettingsScreen(BaseScreen):  # pylint: disable=too-many-ancestors
+    text_input_hint_text_open_ai = StringProperty()
+    text_input_hint_text_stabilty_ai = StringProperty()
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
@@ -22,6 +25,9 @@ class SettingsScreen(BaseScreen):  # pylint: disable=too-many-ancestors
         self.init_open_ai_key()
         self.init_stability_ai_key()
         self.init_ai_temperature()
+        self.text_input_hint_text_open_ai = "Open AI key value (see https://platform.openai.com)"
+        self.text_input_hint_text_stabilty_ai = "Stability AI key value (see https://stability.ai/)"
+        self.set_text_hints()
 
     def init_ai_system_context(self) -> None:
         value = self.service.get(
@@ -85,3 +91,9 @@ class SettingsScreen(BaseScreen):  # pylint: disable=too-many-ancestors
 
     def set_ai_temperature(self, value: int) -> None:
         self.service.set(Preferences.AI_TEMPERATURE.name, round(value, 2))
+
+    # costa-rica: the text is too long on the iPhone if we add the paste button this method will reduce the text_hint length.
+    def set_text_hints(self):
+        if platform == 'ios':
+            self.text_input_hint_text_open_ai = "[Your Open AI key]"
+            self.text_input_hint_text_stabilty_ai = "[Your Stability AI key]"


### PR DESCRIPTION
…_hint for iOS because default text_hint too long

This is response to issue #15.
The solution creates a button in the settings menu for users to paste in the API key MDTextFields.

## Description
This solution replaces the MDTextField with a MDBoxLayout that has the MDTextField and an MDIconButton. Also, the text_hint was too long for iOS devices when the button is added, so I shortened the text when the app is run on an ios device.

I think in the future we might be able to create TextField that responds to user pressing and holding in order to paste as other native devices, but this is an ok solution for the moment.

You can view the solution from building this branch on Xcode and running it on the simulator. This will show the shortening of the text_hint.

Here is a vide/gif of this pull request solution:
![OM_with_pasteButton(2)](https://github.com/amwebexpert/poc-mobile-python/assets/53882857/f4e66d34-5403-4c79-af14-aa6902ba54b5)

## Suggestion
One thing we might want to consider is removing the redundancy in the labeling in the settings menu. Honestly, not sure what to remove, but my instinct is there are too many labels. I'm leaning towards either the MDLabel or the helper_text should be removed for iOS devices. In Python with the big screen, I think it looks good as it is. But in the iPhone it seems a little cluttered and maybe even confusing.


